### PR TITLE
Return proper error messages

### DIFF
--- a/keychain_darwin.c
+++ b/keychain_darwin.c
@@ -5,7 +5,7 @@ char *get_error(OSStatus status) {
     char *buf = malloc(128);
     CFStringRef str = SecCopyErrorMessageString(status, NULL);
     int success = CFStringGetCString(str, buf, 128, kCFStringEncodingUTF8);
-    if (success) {
+    if (!success) {
         strncpy(buf, "Unknown error", 128);
     }
     return buf;

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -21,7 +21,11 @@ func TestFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	pass, err = Find(app, "testuser")
-	if err == nil || err.Error() != "The specified item could not be found in the keychain." || pass != "" {
+	if err == nil || pass != "" {
 		t.Fatal("password remove failed")
+	}
+	strErr := err.Error()
+	if strErr == "" || strErr == "Unknown error" {
+		t.Fatal("problem exporting error message")
 	}
 }

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -1,8 +1,6 @@
 package keychain
 
-import (
-	"testing"
-)
+import "testing"
 
 var app = "github.com/lunixbochs/go-keychain/test"
 
@@ -23,7 +21,7 @@ func TestFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	pass, err = Find(app, "testuser")
-	if err == nil || pass != "" {
+	if err == nil || err.Error() != "The specified item could not be found in the keychain." || pass != "" {
 		t.Fatal("password remove failed")
 	}
 }


### PR DESCRIPTION
The `get_error` function was always returning "Unknown error" because it was checking for `success` instead of `!success`. This PR fixes that and adds a test.